### PR TITLE
[FIX] El endpoint de comentarios se hace  por proyecto

### DIFF
--- a/src/modules/comments/controller/comments.controller.ts
+++ b/src/modules/comments/controller/comments.controller.ts
@@ -39,15 +39,16 @@ export class CommentsController {
   }
 
   /**
-   * Maneja las solicitudes GET para obtener todos los comentarios.
-   * @returns Un array de comentarios.
+   * Maneja las solicitudes GET para obtener todos los comentarios de un proyecto específico.
+   * @param projectId El ID del proyecto cuyos comentarios se desean obtener.
+   * @returns Un array de comentarios del proyecto.
    */
-  @Get()
-  @ApiOperation({ summary: 'Obtener todos los comentarios' })
-  @ApiResponse({ status: 200, description: 'Lista de todos los comentarios.' })
-  @ApiResponse({ status: 401, description: 'No autorizado.' })
-  findAll() {
-    return this.commentsService.findAll();
+  @Get('project/:projectId')
+  @ApiOperation({ summary: 'Obtener todos los comentarios de un proyecto' })
+  @ApiResponse({ status: 200, description: 'Lista de comentarios del proyecto.' })
+  @ApiResponse({ status: 404, description: 'Proyecto o comentarios no encontrados.' })
+  findAllByProject(@Param('projectId') projectId: string) {
+    return this.commentsService.findAllByProject(+projectId);
   }
 
   /**

--- a/src/modules/comments/service/comments.service.ts
+++ b/src/modules/comments/service/comments.service.ts
@@ -76,4 +76,12 @@ export class CommentsService {
       throw new NotFoundException(`Comment with ID ${id} not found`);
     }
   }
+
+  async findAllByProject(projectId: number): Promise<Comments[]> {
+    const comments = await this.commentsRepository.find({ where: { id_project: projectId } });
+    if (!comments || comments.length === 0) {
+      throw new NotFoundException('No se encontraron comentarios para este proyecto');
+    }
+    return comments;
+  }
 }


### PR DESCRIPTION
# 🛠 Pull Request: [FIX] Arreglar Endpoint de Obtener Comentarios por Proyecto

## 📌 Descripción
Este pull request corrige el endpoint `GET /comments` para que ahora devuelva únicamente los comentarios relacionados con un proyecto específico, en lugar de todos los existentes. Esto mejora la precisión en la consulta de comentarios y reduce carga innecesaria en el sistema.

---

## 🎯 Objetivo
Modificar la ruta del controlador y la lógica del servicio para que el sistema devuelva solo los comentarios vinculados al proyecto solicitado por ID, evitando confusión en vistas donde se necesita información contextualizada.

---

## 🚀 Cambios Realizados

### 📁 `comments.controller.ts`
- Se reemplazó la ruta `GET /comments` por `GET /comments/project/:projectId`.
- Se actualizó la documentación Swagger (`@ApiOperation`, `@ApiResponse`) para reflejar correctamente el propósito y posibles errores.
- Nueva función: `findAllByProject(projectId: string)`.

### ⚙️ `comments.service.ts`
- Se agregó el método `findAllByProject(projectId: number)`.
  - Realiza la búsqueda en el repositorio por campo `id_project`.
  - Lanza `NotFoundException` si no se encuentran comentarios.
- Se mantiene el método `findById`, sin cambios.

---

## 📁 Archivos Modificados

- `src/modules/comments/controller/comments.controller.ts` — 9 líneas añadidas, 8 eliminadas.
- `src/modules/comments/service/comments.service.ts` — 8 líneas añadidas.

---