### PR TITLE
81 crear endpoint para buscar alumno por cedula

### DIFF
--- a/src/modules/people/controllers/profile.controller.ts
+++ b/src/modules/people/controllers/profile.controller.ts
@@ -57,6 +57,20 @@ export class ProfileController {
     return this.profileService.findByEmail(email);
   }
 
+  /**
+   * Obtiene un usuario por su cedula
+   * @param id_number Cedula del usuario a buscar
+   */
+  @UseGuards(JwtAuthGuard)
+  @Get('cedula/:id_number')
+  @ApiOperation({ summary: 'Obtener el perfil de un usuario por su cedula' })
+  @ApiResponse({ status: 200, description: 'Perfil del usuario encontrado.' })
+  @ApiResponse({ status: 404, description: 'Usuario no encontrado.' })
+  @ApiResponse({ status: 401, description: 'No autorizado.' })
+  async getByCedula(@Param('id_number') id_number: string) {
+    return this.profileService.findByCedula(id_number);
+  }
+
   @UseGuards(JwtAuthGuard)
   @Put(':id')
   @ApiOperation({

--- a/src/modules/people/services/profile.service.ts
+++ b/src/modules/people/services/profile.service.ts
@@ -2,10 +2,11 @@ import {
   Injectable,
   NotFoundException,
   ConflictException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { People } from '@people/entities/people.entity';
+import { People, UserStatus } from '@people/entities/people.entity';
 import { UpdatePeopleDto } from '@people/dto/register-people.dto';
 import * as bcrypt from 'bcrypt';
 
@@ -110,6 +111,10 @@ export class ProfileService {
 
     if (!user) {
       throw new NotFoundException('Usuario no encontrado');
+    }
+
+    if (user.status !== 'approved') {
+      throw new UnauthorizedException('Usuario no aprobado');
     }
 
     return user;

--- a/src/modules/people/services/profile.service.ts
+++ b/src/modules/people/services/profile.service.ts
@@ -50,6 +50,7 @@ export class ProfileService {
 
     return this.peopleRepository.save(user);
   }
+
   /**
    * Busca un usuario por su email
    * @param email Email del usuario
@@ -57,6 +58,38 @@ export class ProfileService {
   async findByEmail(email: string): Promise<People> {
     const user = await this.peopleRepository.findOne({
       where: { email },
+      select: {
+        id: true,
+        name: true,
+        last_name: true,
+        email: true,
+        user_type: true,
+        status: true,
+        address: true,
+        birthdate: true,
+        phone_number: true,
+        id_number: true,
+        security_question: true,
+        year_of_creation: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    if (!user) {
+      throw new NotFoundException('Usuario no encontrado');
+    }
+
+    return user;
+  }
+
+  /**
+   * Busca un usuario por su cedula
+   * @param cedula Cedula del usuario
+   */
+  async findByCedula(id_number: string): Promise<People> {
+    const user = await this.peopleRepository.findOne({
+      where: { id_number },
       select: {
         id: true,
         name: true,


### PR DESCRIPTION
# 🆔 Pull Request: Obtener Usuario por Cédula — Issue #81

## 📌 Descripción
Este pull request implementa un nuevo endpoint en el módulo `Profile`, que permite a usuarios autenticados consultar la información de cualquier persona registrada mediante su número de cédula (`id_number`). Esta búsqueda está protegida por autenticación JWT y válida únicamente si el usuario está aprobado.

---

## 🎯 Objetivo
Agregar una consulta directa por documento de identidad, útil para validaciones académicas, administración de perfiles y consultas administrativas, evitando llamadas innecesarias por ID interno o correo.

---

## 🚀 Cambios Realizados

### 📄 Controlador `profile.controller.ts`
- Endpoint añadido: GET /profile/cedula/:id_number

---

## 📁 Archivos Modificados

- `src/modules/people/controllers/profile.controller.ts` → +14 líneas
- `src/modules/people/services/profile.service.ts` → +39 líneas
- Total: 2 archivos modificados, 53 líneas añadidas, 1 línea eliminada

---

## ✅ Resultado Esperado

- El sistema permite obtener el perfil de un usuario por su número de cédula.
- Solo se retorna si el usuario está aprobado, garantizando control de acceso.
- Endpoint usable por módulos administrativos o validadores externos.

---

## 👥 Autores

- `Luisca67` — Implementación inicial
- `Santacruzluis` — Validación de lógica y acceso por estado aprobado

---
