### PR TITLE
[ADD] Se agregaron enpoint para eliminar categorias y tecnologias

### DIFF
--- a/src/modules/category/controllers/category.controller.ts
+++ b/src/modules/category/controllers/category.controller.ts
@@ -6,6 +6,7 @@ import {
   Put,
   Param,
   UseGuards,
+  Delete,
 } from '@nestjs/common';
 import { CategoryService } from '@category/services/category.service';
 import { CreateCategoryDto, UpdateCategoryDto } from '@category/dto/category.dto';
@@ -58,5 +59,16 @@ export class CategoryController {
   @ApiResponse({ status: 401, description: 'No autorizado.' })
   async updateById(@Param('id') id: string, @Body() updateCategoryDto: UpdateCategoryDto) {
     return this.categoryService.updateById(id, updateCategoryDto);
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserType.ADMIN)
+  @Delete(':id')
+  @ApiOperation({ summary: 'Eliminar una categoría por su ID (Solo para administradores)' })
+  @ApiResponse({ status: 200, description: 'La categoría ha sido eliminada exitosamente.' })
+  @ApiResponse({ status: 404, description: 'Categoría no encontrada.' })
+  @ApiResponse({ status: 401, description: 'No autorizado.' })
+  async deleteById(@Param('id') id: string) {
+    return this.categoryService.deleteById(id);
   }
 }

--- a/src/modules/technology/controllers/technology.controller.ts
+++ b/src/modules/technology/controllers/technology.controller.ts
@@ -6,6 +6,7 @@ import {
   Put,
   Param,
   UseGuards,
+  Delete,
 } from '@nestjs/common';
 import { TechnologyService } from '@technology/services/technology.service';
 import {
@@ -64,5 +65,16 @@ export class TechnologyController {
     @Body() changes: UpdateTechnologyDto,
   ) {
     return this.technologyService.updateById(id, changes);
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserType.ADMIN)
+  @Delete(':id')
+  @ApiOperation({ summary: 'Eliminar una tecnología por su ID (Solo para administradores)' })
+  @ApiResponse({ status: 200, description: 'La tecnología ha sido eliminada exitosamente.' })
+  @ApiResponse({ status: 404, description: 'Tecnología no encontrada.' })
+  @ApiResponse({ status: 401, description: 'No autorizado.' })
+  async deleteById(@Param('id') id: number) {
+    return this.technologyService.deleteById(id);
   }
 }

--- a/src/modules/technology/services/technology.service.ts
+++ b/src/modules/technology/services/technology.service.ts
@@ -87,4 +87,11 @@ export class TechnologyService {
     Object.assign(technology, changes);
     return await this.technologyRepository.save(technology);
   }
+
+  async deleteById(id: number): Promise<string> {
+    const technology = await this.findById(id);
+
+    await this.technologyRepository.remove(technology);
+    return `Se eliminó la tecnología "${technology.name}"`;
+  }
 }


### PR DESCRIPTION
# 🗑️ Pull Request: Eliminar Categorías y Tecnologías — Issue #90

## 📌 Descripción
Este pull request agrega dos nuevos endpoints al sistema, permitiendo a los administradores eliminar categorías y tecnologías directamente desde el backend. La acción está protegida por autenticación JWT y el rol `ADMIN`.

---

## 🎯 Objetivo
Facilitar la limpieza y mantenimiento de datos en los módulos `Category` y `Technology`, permitiendo eliminar registros obsoletos o incorrectos de forma controlada y segura.

---

## 🚀 Cambios Realizados

### 🔧 Controlador de Categorías (`category.controller.ts`)
- Endpoint creado: 
DELETE /category/:id
DELETE /technology/:id
