### PR TITLE
fix bug Validacion de no asignar al mismo estudiante a una materia do…

### DIFF
--- a/src/modules/subject/services/subject-people.service.ts
+++ b/src/modules/subject/services/subject-people.service.ts
@@ -53,6 +53,18 @@ export class SubjectPeopleService {
     });
     if (!subject) throw new NotFoundException('Materia no encontrada');
 
+    // Evita asignar la misma materia dos veces al mismo estudiante
+    const alreadyAssigned = await this.subjectPeopleRepo.findOne({
+      where: {
+        people: { id: dto.peopleid },
+        subject: { id: dto.subjectid },
+      },
+    });
+    if (alreadyAssigned) {
+      throw new BadRequestException(
+        'El estudiante ya está asignado a esta materia.',
+      );
+    }
     // Validación de requisitos si es estudiante
     if (people.user_type === 'student') {
       if (


### PR DESCRIPTION
# ✅ Pull Request: Validación al Asignar Materia — Issue #92

## 📌 Descripción
Este pull request introduce una mejora crucial en el módulo de asignación de materias. Se agrega una validación preventiva que evita que un estudiante sea inscrito más de una vez en la misma materia, preservando la integridad académica y evitando duplicaciones en la base de datos.

---

## 🎯 Objetivo
Prevenir inscripciones repetidas a una misma materia por parte de un estudiante, asegurando una única relación válida entre persona y materia.

---

## 📁 Archivos Modificados

src/modules/subject/services/subject/peolple.service.ts

##✅ Resultado Esperado
Si se intenta asignar una materia que ya pertenece al estudiante, el sistema arroja una excepción tipo BadRequestException.

Se refuerza la confiabilidad del módulo SubjectPeople.

Evita errores lógicos en vistas administrativas, evaluaciones y generación de reportes.

##👥Autor 

Luisca67
