### PR TITLE
FIX validacion de que no se puedn asignar materias a un administrador

### DIFF
--- a/src/modules/subject/services/subject-people.service.ts
+++ b/src/modules/subject/services/subject-people.service.ts
@@ -48,6 +48,13 @@ export class SubjectPeopleService {
     });
     if (!people) throw new NotFoundException('Persona no encontrada');
 
+    // Validación: no se pueden asignar materias a usuarios admin
+    if (people.user_type === UserType.ADMIN) {
+      throw new BadRequestException(
+        'No se pueden asignar materias a usuarios administradores.',
+      );
+    }
+
     const subject = await this.subjectRepo.findOne({
       where: { id: dto.subjectid },
     });


### PR DESCRIPTION
# 🛡️ Validación para evitar asignación de materias a administradores

Este Pull Request introduce una validación que impide asignar materias a usuarios con rol de administrador (`ADMIN`), reforzando las reglas de negocio y previniendo errores lógicos en el sistema académico.

## 🔧 Cambios Realizados

### Servicio (`subject-people.service.ts`)
- [ADD] Validación explícita: si el usuario tiene el tipo `ADMIN`, se lanza una excepción `BadRequestException` con el mensaje _"No se pueden asignar materias a usuarios administradores."_.
- [MOD] Se añadió esta lógica antes de la carga de la materia (`subjectRepo.findOne`) para abortar el flujo de asignación anticipadamente.

## 📁 Archivo Modificado
- `src/modules/subject/services/subject-people.service.ts`: +7 líneas de código

## 🎯 Motivación

Los administradores del sistema no deben participar directamente como sujetos en asignaturas. Esta restricción evita conflictos en roles, asegura integridad del flujo académico y facilita el mantenimiento del sistema.

## 🚨 Excepciones

Se lanza:
```ts
throw new BadRequestException(
  'No se pueden asignar materias a usuarios administradores.',
);
