### PR TITLE
[ADD] Se agrego ep para ver los archivos subidos en un proyecto y par…

### DIFF
--- a/src/modules/people/entities/project-file.entity.ts
+++ b/src/modules/people/entities/project-file.entity.ts
@@ -22,6 +22,9 @@ export class ProjectFile {
   @Column({ default: 'file' })
   type: string;
 
+  @Column({ nullable: true })
+  external_link: string;
+
   @CreateDateColumn()
   created_at: Date;
 


### PR DESCRIPTION
# 📦 Pull Request: Endpoint para editar archivos subidos por el estudiante

## ✨ Descripción

Este PR agrega funcionalidades para visualizar, editar y actualizar los archivos o enlaces que los estudiantes han subido a sus proyectos. Se implementan nuevos endpoints y se actualiza la lógica del controlador para manejar enlaces externos asociados a los archivos.

---

## 🚀 Nuevas funcionalidades

- **GET `/projectfile/:projectId`**
  - Retorna archivos y enlaces subidos por un estudiante para un proyecto específico.
  - Requiere autenticación JWT.

- **PUT `/projectfile/:fileId`**
  - Permite editar un archivo existente o su enlace externo asociado.
  - Soporta la sustitución del archivo y actualización de metadatos como el enlace externo.

---

## 🧱 Cambios realizados

- Se agregaron nuevos métodos al `StudenFileController`:
  - `getProjectFiles` para obtener archivos por proyecto.
  - `updateProjectFile` para editar archivos existentes.
- Se amplió el schema Swagger para incluir la propiedad `external_link`.
- Se actualizó la entidad `ProjectFile` para soportar enlaces externos.
- Se agregó validación para tipos de archivos permitidos (PDF, DOC, imágenes, etc.).
- Se mejoró la estructura de respuesta en los endpoints, separando archivos y enlaces.

---

